### PR TITLE
Change `re_match` to `regex.match`

### DIFF
--- a/recipe-4/policy.rego
+++ b/recipe-4/policy.rego
@@ -6,6 +6,6 @@ match if count(reason) > 0
 
 reason contains msg if {
   pkg := input.v0["package"]
-  re_match(".*(debug|test|tmp).*", pkg.filename)
+  regex.match(".*(debug|test|tmp).*", pkg.filename)
   msg := sprintf("Debug/test artifact detected in filename: %s", [pkg.filename])
 }


### PR DESCRIPTION
`re_match` has been deprecated because it was renamed to `regex.match`.

https://github.com/open-policy-agent/opa/blob/main/docs/projects/regal/rules/bugs/deprecated-builtin.md#re_match-and-netcidr_overlap