### PR TITLE
Include id record in alias index and id/aliases to work with ignored

### DIFF
--- a/baseline/high-risk-vulnerability.rego
+++ b/baseline/high-risk-vulnerability.rego
@@ -12,13 +12,13 @@ ignored := {}
 match if count(reason) > 0
 
 aliased_records[k] contains v if {
-    some v in input.v0.osv
-    some k in {v.id} | {a | some a in v.aliases}
+	some v in input.v0.osv
+	some k in ({v.id} | {a | some a in v.aliases})
 }
 
 blocking_keys contains k if {
 	some k, records in aliased_records
-	every v in records { 
+	every v in records {
 		not v.id in ignored
 		every a in v.aliases { not a in ignored }
 	}
@@ -48,7 +48,7 @@ max_cvss_for_key(k) := max(scores) if {
 
 fixed_versions_for_key(k) := {f |
 	some v in aliased_records[k]
-    f := v.affected[_].ranges[_].events[_].fixed
+	f := v.affected[_].ranges[_].events[_].fixed
 }
 
 has_fix_for_key(k) if {

--- a/baseline/high-risk-vulnerability.rego
+++ b/baseline/high-risk-vulnerability.rego
@@ -11,20 +11,17 @@ ignored := {}
 
 match if count(reason) > 0
 
-vuln_keys(v) := {a | some a in v.aliases} if {
-	count(v.aliases) > 0
-} else := {v.id}
-
-aliased_records[k] := records if {
-	input.v0.osv != null
-	some v_seed in input.v0.osv
-	some k in vuln_keys(v_seed)
-	records := {v | some v in input.v0.osv; k in vuln_keys(v)}
+aliased_records[k] contains v if {
+    some v in input.v0.osv
+    some k in {v.id} | {a | some a in v.aliases}
 }
 
 blocking_keys contains k if {
-	some k, _ in aliased_records
-	not k in ignored
+	some k, records in aliased_records
+	every v in records { 
+		not v.id in ignored
+		every a in v.aliases { not a in ignored }
+	}
 	max_cvss_for_key(k) >= min_cvss
 	has_fix_for_key(k)
 }
@@ -49,12 +46,9 @@ max_cvss_for_key(k) := max(scores) if {
 	count(scores) > 0
 } else := 0.0
 
-fixed_versions_for_key(k) := {e.fixed |
+fixed_versions_for_key(k) := {f |
 	some v in aliased_records[k]
-	some a in v.affected
-	some r in a.ranges
-	some e in r.events
-	e.fixed
+    f := v.affected[_].ranges[_].events[_].fixed
 }
 
 has_fix_for_key(k) if {

--- a/tests/baseline/high-risk-vulnerability_test.rego
+++ b/tests/baseline/high-risk-vulnerability_test.rego
@@ -99,7 +99,7 @@ test_match_cross_record_score_and_fix if {
 			},
 			{
 				"id": "CVE-2021-9999",
-				"aliases": [],
+				"aliases": ["GHSA-xxxx-xxxx-xxxx"],
 				"severity": [],
 				"affected": [{"severity": [], "ranges": [{"events": [{"fixed": "1.0.1"}]}]}],
 			},

--- a/tests/baseline/high-risk-vulnerability_test.rego
+++ b/tests/baseline/high-risk-vulnerability_test.rego
@@ -124,7 +124,8 @@ test_no_match_when_id_ignored if {
 	not data.cloudsmith.match with input as {"v0": {
 		"osv": [_vuln_with_fix("CVE-2021-1234", 9.0)],
 		"package": _package,
-	}} with data.cloudsmith.ignored as {"CVE-2021-1234"}
+	}}
+		with data.cloudsmith.ignored as {"CVE-2021-1234"}
 }
 
 test_no_match_when_alias_ignored if {
@@ -136,14 +137,16 @@ test_no_match_when_alias_ignored if {
 			"affected": [{"severity": [], "ranges": [{"events": [{"fixed": "1.0.1"}]}]}],
 		}],
 		"package": _package,
-	}} with data.cloudsmith.ignored as {"CVE-2021-9999"}
+	}}
+		with data.cloudsmith.ignored as {"CVE-2021-9999"}
 }
 
 test_match_when_different_id_ignored if {
 	data.cloudsmith.match with input as {"v0": {
 		"osv": [_vuln_with_fix("CVE-2021-1234", 9.0)],
 		"package": _package,
-	}} with data.cloudsmith.ignored as {"CVE-2021-0000"}
+	}}
+		with data.cloudsmith.ignored as {"CVE-2021-0000"}
 }
 
 test_no_match_when_both_aliased_records_ignored if {
@@ -163,7 +166,8 @@ test_no_match_when_both_aliased_records_ignored if {
 			},
 		],
 		"package": _package,
-	}} with data.cloudsmith.ignored as {"CVE-2021-9999"}
+	}}
+		with data.cloudsmith.ignored as {"CVE-2021-9999"}
 }
 
 test_no_match_when_asymmetric_alias_ignored if {
@@ -183,7 +187,8 @@ test_no_match_when_asymmetric_alias_ignored if {
 			},
 		],
 		"package": _package,
-	}} with data.cloudsmith.ignored as {"CVE-2021-9999"}
+	}}
+		with data.cloudsmith.ignored as {"CVE-2021-9999"}
 }
 
 # ── Reason messages ───────────────────────────────────────────────────────────

--- a/tests/baseline/high-risk-vulnerability_test.rego
+++ b/tests/baseline/high-risk-vulnerability_test.rego
@@ -118,6 +118,74 @@ test_no_match_cross_record_separate_keys if {
 	}}
 }
 
+# ── Ignored ────────────────────────────────────────────────────────────────────
+
+test_no_match_when_id_ignored if {
+	not data.cloudsmith.match with input as {"v0": {
+		"osv": [_vuln_with_fix("CVE-2021-1234", 9.0)],
+		"package": _package,
+	}} with data.cloudsmith.ignored as {"CVE-2021-1234"}
+}
+
+test_no_match_when_alias_ignored if {
+	not data.cloudsmith.match with input as {"v0": {
+		"osv": [{
+			"id": "GHSA-xxxx-xxxx-xxxx",
+			"aliases": ["CVE-2021-9999"],
+			"severity": [{"numerical_score": 9.0}],
+			"affected": [{"severity": [], "ranges": [{"events": [{"fixed": "1.0.1"}]}]}],
+		}],
+		"package": _package,
+	}} with data.cloudsmith.ignored as {"CVE-2021-9999"}
+}
+
+test_match_when_different_id_ignored if {
+	data.cloudsmith.match with input as {"v0": {
+		"osv": [_vuln_with_fix("CVE-2021-1234", 9.0)],
+		"package": _package,
+	}} with data.cloudsmith.ignored as {"CVE-2021-0000"}
+}
+
+test_no_match_when_both_aliased_records_ignored if {
+	not data.cloudsmith.match with input as {"v0": {
+		"osv": [
+			{
+				"id": "GHSA-xxxx-xxxx-xxxx",
+				"aliases": ["CVE-2021-9999"],
+				"severity": [{"numerical_score": 9.0}],
+				"affected": [{"severity": [], "ranges": [{"events": []}]}],
+			},
+			{
+				"id": "CVE-2021-9999",
+				"aliases": ["GHSA-xxxx-xxxx-xxxx"],
+				"severity": [],
+				"affected": [{"severity": [], "ranges": [{"events": [{"fixed": "1.0.1"}]}]}],
+			},
+		],
+		"package": _package,
+	}} with data.cloudsmith.ignored as {"CVE-2021-9999"}
+}
+
+test_no_match_when_asymmetric_alias_ignored if {
+	not data.cloudsmith.match with input as {"v0": {
+		"osv": [
+			{
+				"id": "GHSA-xxxx-xxxx-xxxx",
+				"aliases": [],
+				"severity": [{"numerical_score": 9.0}],
+				"affected": [{"severity": [], "ranges": [{"events": [{"fixed": "2.0.0"}]}]}],
+			},
+			{
+				"id": "CVE-2021-9999",
+				"aliases": ["GHSA-xxxx-xxxx-xxxx"],
+				"severity": [],
+				"affected": [{"severity": [], "ranges": [{"events": []}]}],
+			},
+		],
+		"package": _package,
+	}} with data.cloudsmith.ignored as {"CVE-2021-9999"}
+}
+
 # ── Reason messages ───────────────────────────────────────────────────────────
 
 test_reason_message if {


### PR DESCRIPTION
* Shorten `aliased_records` index setup and include record of `id` in it.
* Make `ignored` work with record of id, and records that have aliases (that are both present in the dataset and not).
* Shorten `fixed_versions_for_key` - Rego style guide says "old" style of iteration is likely preferable when it's a deeply nested structure: https://www.openpolicyagent.org/docs/style-guide#prefer-some--in-for-iteration