### PR TITLE
Add metadata to baseline policies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 # Policy METADATA
 
-- All policies should include METADATA comments at the top of the file
+- All new policies (and any existing policies you modify) should include METADATA comments at the top of the file
 - Place METADATA before the `package` declaration
 
 ## Format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,25 @@
 # Style and linting
+
 - Use https://www.openpolicyagent.org/docs/style-guide for style when modifying or creating recipes
 - Use/suggest `opa fmt` when finished e.g. `opa fmt -w .`
+
+# Policy METADATA
+
+- All policies should include METADATA comments at the top of the file
+- Place METADATA before the `package` declaration
+
+## Format
+
+```rego
+# METADATA
+# title: <Display Title>
+# description: <Brief description of what the policy does>
+package cloudsmith
+```
+
+## Guidelines
+
+- `title`: Short, human-readable display name in sentence case (e.g., "Malware block")
+- `description`: One-line summary of policy behavior (e.g., "Block packages with detected malware vulnerabilities (MAL- prefix)")
+- Keep descriptions concise and action-oriented
+- Follow OPA METADATA annotations format: https://www.openpolicyagent.org/docs/policy-language#metadata

--- a/baseline/exact-allowlist-exemption.rego
+++ b/baseline/exact-allowlist-exemption.rego
@@ -1,3 +1,6 @@
+# METADATA
+# title: Exact allowlist exemption
+# description: Approve packages that are explicitly allowlisted by format, name, and version
 package cloudsmith
 
 default match := false

--- a/baseline/exact-blocklist.rego
+++ b/baseline/exact-blocklist.rego
@@ -1,6 +1,6 @@
 # METADATA
 # title: Exact blocklist
-# description: Quarantine packages that are explicitly denylisted by format, name, and version.
+# description: Flag packages that are explicitly denylisted by format, name, and version.
 package cloudsmith
 
 default match := false

--- a/baseline/exact-blocklist.rego
+++ b/baseline/exact-blocklist.rego
@@ -1,3 +1,6 @@
+# METADATA
+# title: Exact blocklist
+# description: Quarantine packages that are explicitly denylisted by format, name, and version.
 package cloudsmith
 
 default match := false

--- a/baseline/license-compliance.rego
+++ b/baseline/license-compliance.rego
@@ -1,3 +1,6 @@
+# METADATA
+# title: License compliance
+# description: Flag packages with copyleft licenses (GPL, LGPL, AGPL, MPL, etc.)
 package cloudsmith
 
 default match := false

--- a/baseline/malware-block.rego
+++ b/baseline/malware-block.rego
@@ -1,3 +1,6 @@
+# METADATA
+# title: Malware block
+# description: Quarantine packages with detected malware vulnerabilities
 package cloudsmith
 
 default match := false

--- a/baseline/malware-block.rego
+++ b/baseline/malware-block.rego
@@ -1,6 +1,6 @@
 # METADATA
 # title: Malware block
-# description: Quarantine packages with detected malware vulnerabilities
+# description: Flag packages with detected malware vulnerabilities
 package cloudsmith
 
 default match := false

--- a/baseline/package-age-quarantine.rego
+++ b/baseline/package-age-quarantine.rego
@@ -1,3 +1,6 @@
+# METADATA
+# title: Package age quarantine
+# description: Quarantine packages published within the last N days
 package cloudsmith
 
 default match := false

--- a/baseline/package-age-quarantine.rego
+++ b/baseline/package-age-quarantine.rego
@@ -1,6 +1,6 @@
 # METADATA
 # title: Package age quarantine
-# description: Quarantine packages published within the last N days
+# description: Flag packages published within the last N days
 package cloudsmith
 
 default match := false

--- a/baseline/package-age-restore.rego
+++ b/baseline/package-age-restore.rego
@@ -1,3 +1,6 @@
+# METADATA
+# title: Package age restore
+# description: Restore packages that are older than N days
 package cloudsmith
 
 default match := false


### PR DESCRIPTION
This pull request standardises and documents the use of METADATA annotations for OPA policy files.

It updates documentation to require METADATA blocks at the top of each policy, and adds these blocks to all baseline policies to improve clarity and maintainability.