### PR TITLE
Convert repo into consumable npm package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,9 +183,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
@@ -206,3 +206,17 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Dependencies
+node_modules/
+
+# npm
+npm-debug.log*
+*.tgz
+
+# macOS
+.DS_Store
+
+# Editor directories
+.vscode/
+.idea/

--- a/NPM.md
+++ b/NPM.md
@@ -1,0 +1,103 @@
+# Using Rego Recipes as an npm Package
+
+This repository can be consumed as an npm package in JavaScript/TypeScript applications to power policy management UIs.
+
+---
+
+## Installation
+
+```bash
+npm install github:cloudsmith-io/rego-recipes
+```
+
+Specify a branch/tag/commit:
+
+```bash
+npm install github:cloudsmith-io/rego-recipes#main
+npm install github:cloudsmith-io/rego-recipes#v1.0.0
+```
+
+---
+
+## Usage
+
+```typescript
+import {
+  baselineMalwareBlock,
+  baselinePolicies,
+  allPolicies,
+  type Policy,
+} from '@cloudsmith/rego-recipes';
+
+// Access individual policy
+console.log(baselineMalwareBlock.content); // The raw .rego file content
+
+// Use collections
+baselinePolicies.forEach((policy) => {
+  console.log(policy.title, policy.path, policy.content);
+});
+
+// Use the Policy type
+function displayPolicy(policy: Policy) {
+  return `${policy.title}: ${policy.description}`;
+}
+```
+
+---
+
+## Available Exports
+
+### Individual Policies
+
+**Baseline:**
+
+- `baselineExactAllowlistExemption`
+- `baselineExactBlocklist`
+- `baselineHighRiskVulnerability`
+- `baselineLicenseCompliance`
+- `baselineMalwareBlock`
+- `baselinePackageAgeQuarantine`
+- `baselinePackageAgeRestore`
+
+**Advanced:**
+
+- `advancedHuggingfaceRecipesModelCard`
+- `advancedHuggingfaceRecipesRiskyFiles`
+- `advancedHuggingfaceRecipesSecurityScan`
+- `advancedHuggingfaceRecipesTrustedPublishers`
+
+**Legacy:**
+
+- `legacyRecipe1Policy` through `legacyRecipe21Policy` (deprecated)
+
+### Collections
+
+- `baselinePolicies` - All baseline policies
+- `advancedPolicies` - All advanced policies
+- `legacyPolicies` - All legacy policies (deprecated)
+- `allPolicies` - All policies
+
+### TypeScript Types
+
+**`Policy`** - Interface for policy objects:
+
+```typescript
+import { type Policy } from '@cloudsmith/rego-recipes';
+
+// Policy structure:
+interface Policy {
+  id: string; // unique identifier (camelCase)
+  title: string; // display title (from METADATA or sentence case filename)
+  description: string; // policy description (from METADATA or empty)
+  path: string; // relative path from package root
+  content: string; // raw .rego file content
+}
+```
+
+---
+
+## Development
+
+```bash
+npm run build  # Generate dist/index.js and dist/index.d.ts
+```

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ The goal of this repository is to define a clear, recommended secure baseline fo
 
 All policies in this repository:
 
-- Are WASM-compatible  
-- Use only supported Cloudsmith EPM builtins  
-- Avoid deprecated syntax (e.g. `import rego.v1`)  
-- Follow OPA style guidelines  
-- Are structured for composability using precedence  
-- Are safe for production use  
+- Are WASM-compatible
+- Use only supported Cloudsmith EPM builtins
+- Avoid deprecated syntax (e.g. `import rego.v1`)
+- Follow OPA style guidelines
+- Are structured for composability using precedence
+- Are safe for production use
 
 These policies are intended to be readable, predictable, and suitable for enterprise environments.
 
@@ -43,11 +43,11 @@ Recommended secure defaults for production environments.
 
 These policies address common supply chain security requirements such as:
 
-- Malware blocking  
-- High-risk vulnerability control (CVSS / EPSS)  
-- License compliance  
-- Workflows using package age  
-- Explicit allowlist and blocklist handling  
+- Malware blocking
+- High-risk vulnerability control (CVSS / EPSS)
+- License compliance
+- Workflows using package age
+- Explicit allowlist and blocklist handling
 
 If you are deploying EPM in a new workspace, start here.
 
@@ -59,10 +59,10 @@ Optional or format-specific policies that provide deeper governance controls.
 
 These may include:
 
-- Base image origin enforcement  
-- SBOM-based controls  
-- Model governance policies  
-- Specialized workflow patterns  
+- Base image origin enforcement
+- SBOM-based controls
+- Model governance policies
+- Specialized workflow patterns
 
 Advanced policies are production-ready but not universally required.
 
@@ -74,9 +74,9 @@ Historical recipes and experimental policies retained for reference.
 
 Policies in this directory:
 
-- May use older patterns  
-- May not reflect current schema or best practices  
-- Are not recommended for new deployments  
+- May use older patterns
+- May not reflect current schema or best practices
+- Are not recommended for new deployments
 
 They are preserved for documentation history and migration reference.
 
@@ -108,10 +108,10 @@ A recommended precedence pattern for baseline deployments is:
 6. Exact blocklist (explicit deny)
 7. Malware block (final quarantine safeguard)
 
-All matched policy actions are applied within a single transaction.  
+All matched policy actions are applied within a single transaction.
 The package state visible to users reflects the final committed result.
 
-For full EPM documentation, see:  
+For full EPM documentation, see:
 https://docs.cloudsmith.com/supply-chain-security/epm
 
 ---
@@ -127,10 +127,7 @@ Pull Requests, and automatically applied to Cloudsmith on merge.
 1. Maintain an exemption list in the format `format:name:version`:
 
 ```json
-[
-  "python:requests:2.6.4",
-  "npm:left-pad:1.3.0"
-]
+["python:requests:2.6.4", "npm:left-pad:1.3.0"]
 ```
 
 2. Open a Pull Request for security/DevOps review.
@@ -161,3 +158,10 @@ This repository is the single source of truth for:
 - Secure baseline recommendations
 - Enterprise EPM enablement guidance
 
+---
+
+## Using as npm Package
+
+For JavaScript/TypeScript integration (e.g., policy management UIs), this repository can be installed as an npm package directly from GitHub.
+
+See [NPM.md](NPM.md) for installation instructions and usage examples.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "@cloudsmith/rego-recipes",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cloudsmith/rego-recipes",
+      "version": "1.0.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@cloudsmith/rego-recipes",
+  "version": "1.0.0",
+  "description": "Curated, production-ready Open Policy Agent (OPA) policies for Cloudsmith Enterprise Policy Management (EPM)",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/",
+    "baseline/",
+    "advanced/",
+    "legacy/",
+    "NPM.md"
+  ],
+  "scripts": {
+    "build": "node scripts/build.js",
+    "prepare": "npm run build"
+  },
+  "keywords": [
+    "opa",
+    "open-policy-agent",
+    "rego",
+    "cloudsmith",
+    "policy",
+    "security",
+    "supply-chain",
+    "epm",
+    "enterprise-policy-management"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cloudsmith-io/rego-recipes.git"
+  },
+  "author": "Cloudsmith",
+  "bugs": {
+    "url": "https://github.com/cloudsmith-io/rego-recipes/issues"
+  },
+  "homepage": "https://github.com/cloudsmith-io/rego-recipes#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+// Copyright 2026 Cloudsmith Ltd
+
+import { readdir, readFile, writeFile, mkdir } from 'fs/promises';
+import { join, relative, basename } from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const rootDir = join(__dirname, '..');
+const distDir = join(rootDir, 'dist');
+
+/**
+ * Recursively find all .rego files in a directory
+ * @param {string} dir - Directory to search
+ * @param {string} baseDir - Base directory for relative paths
+ * @returns {Promise<Array<{absolutePath: string, relativePath: string, name: string}>>}
+ */
+async function findRegoFiles(dir, baseDir = dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      const subFiles = await findRegoFiles(fullPath, baseDir);
+      files.push(...subFiles);
+    } else if (entry.isFile() && entry.name.endsWith('.rego')) {
+      const relativePath = relative(baseDir, fullPath);
+      files.push({
+        absolutePath: fullPath,
+        relativePath,
+        name: basename(entry.name, '.rego'),
+      });
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Convert a file path to a safe JavaScript identifier
+ * Uses the full path to ensure uniqueness (e.g., legacy/recipe-1/policy.rego -> legacyRecipe1Policy)
+ * @param {string} path - File path to convert (e.g., "baseline/cooldown.rego")
+ * @returns {string}
+ */
+function toSafeIdentifier(path) {
+  // Remove .rego extension and convert path separators, hyphens, underscores to camelCase
+  return path
+    .replace(/\.rego$/, '') // Remove .rego extension
+    .replace(/[\/\-_]([a-z])/g, (_, char) => char.toUpperCase()) // Convert separators to camelCase
+    .replace(/^([a-z])/, (_, char) => char.toLowerCase()) // Ensure first char is lowercase
+    .replace(/[^a-zA-Z0-9]/g, ''); // Remove any remaining special chars
+}
+
+/**
+ * Format a filename to sentence case
+ * @param {string} filename - Filename without extension (e.g., "malware-block")
+ * @returns {string} - Sentence case version (e.g., "Malware block")
+ */
+function formatFilenameToTitle(filename) {
+  const words = filename.split(/[-_]/).join(' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * Escape string content for use in JavaScript template literals
+ * @param {string} content - Content to escape
+ * @returns {string}
+ */
+function escapeTemplateString(content) {
+  return content
+    .replace(/\\/g, '\\\\') // Escape backslashes
+    .replace(/`/g, '\\`') // Escape backticks
+    .replace(/\$/g, '\\$'); // Escape dollar signs
+}
+
+/**
+ * Extract metadata from METADATA comments in .rego file
+ * @param {string} content - The .rego file content
+ * @returns {{title: string, description: string}}
+ */
+function extractMetadata(content) {
+  const metadata = {
+    title: '',
+    description: '',
+  };
+
+  // Look for METADATA block at start of file
+  const metadataRegex = /^#\s*METADATA\s*\n((?:#.*\n)*)/m;
+  const match = content.match(metadataRegex);
+
+  if (!match) {
+    return metadata;
+  }
+
+  const metadataBlock = match[1];
+
+  // Extract title
+  const titleMatch = metadataBlock.match(/^#\s*title:\s*(.+)$/m);
+  if (titleMatch) {
+    metadata.title = titleMatch[1].trim();
+  }
+
+  // Extract description
+  const descMatch = metadataBlock.match(/^#\s*description:\s*(.+)$/m);
+  if (descMatch) {
+    metadata.description = descMatch[1].trim();
+  }
+
+  return metadata;
+}
+
+/**
+ * Generate the main index.js module
+ * @param {Array<{absolutePath: string, relativePath: string, name: string}>} policies
+ * @param {Record<string, Array<{absolutePath: string, relativePath: string, name: string}>>} policiesByDir
+ * @returns {Promise<void>}
+ */
+async function generateIndexJs(policies, policiesByDir) {
+  const contentDeclarations = [];
+  const exports = [];
+
+  for (const policy of policies) {
+    const identifier = toSafeIdentifier(policy.relativePath);
+
+    // Read the .rego file content and inline it
+    const regoContent = await readFile(policy.absolutePath, 'utf-8');
+    const escapedContent = escapeTemplateString(regoContent);
+
+    // Extract metadata
+    const metadata = extractMetadata(regoContent);
+
+    // Use METADATA title or format filename as fallback
+    const title = metadata.title || formatFilenameToTitle(policy.name);
+
+    contentDeclarations.push(
+      `const ${identifier}Content = \`${escapedContent}\`;`,
+    );
+
+    exports.push(
+      `export const ${identifier} = {
+  id: '${identifier}',
+  title: '${escapeTemplateString(title)}',
+  description: '${escapeTemplateString(metadata.description)}',
+  path: '${policy.relativePath}',
+  content: ${identifier}Content,
+};`,
+    );
+  }
+
+  const content = `// Copyright 2026 Cloudsmith Ltd
+// Auto-generated by scripts/build.js - DO NOT EDIT
+
+${contentDeclarations.join('\n\n')}
+
+${exports.join('\n\n')}
+
+// Export policies by category
+export const baselinePolicies = [
+  ${policiesByDir.baseline?.map((p) => toSafeIdentifier(p.relativePath)).join(',\n  ') || ''},
+];
+
+export const advancedPolicies = [
+  ${policiesByDir.advanced?.map((p) => toSafeIdentifier(p.relativePath)).join(',\n  ') || ''},
+];
+
+export const legacyPolicies = [
+  ${policiesByDir.legacy?.map((p) => toSafeIdentifier(p.relativePath)).join(',\n  ') || ''},
+];
+
+// Export all policies as a collection
+export const allPolicies = [
+  ${policies.map((p) => toSafeIdentifier(p.relativePath)).join(',\n  ')},
+];
+`;
+
+  await writeFile(join(distDir, 'index.js'), content, 'utf-8');
+}
+
+/**
+ * Generate the index.d.ts TypeScript definitions
+ * @param {Array<{absolutePath: string, relativePath: string, name: string}>} policies
+ * @param {Record<string, Array<{absolutePath: string, relativePath: string, name: string}>>} policiesByDir
+ * @returns {Promise<void>}
+ */
+async function generateIndexDts(policies, policiesByDir) {
+  const interfaces = [];
+  const exports = [];
+
+  const policyInterface = `export interface Policy {
+  /** Unique identifier (camelCase version of path) */
+  id: string;
+  /** Display title (from METADATA or sentence case filename) */
+  title: string;
+  /** Policy description (from METADATA or empty string) */
+  description: string;
+  /** Relative path to the .rego file from package root */
+  path: string;
+  /** The raw .rego file content as a string */
+  content: string;
+}`;
+
+  for (const policy of policies) {
+    const identifier = toSafeIdentifier(policy.relativePath);
+    exports.push(`export const ${identifier}: Policy;`);
+  }
+
+  const content = `// Copyright 2026 Cloudsmith Ltd
+// Auto-generated by scripts/build.js - DO NOT EDIT
+
+${policyInterface}
+
+${exports.join('\n')}
+
+/** Baseline policies collection */
+export const baselinePolicies: Policy[];
+
+/** Advanced policies collection */
+export const advancedPolicies: Policy[];
+
+/** Legacy policies collection (deprecated) */
+export const legacyPolicies: Policy[];
+
+/** All policies as a collection */
+export const allPolicies: Policy[];
+`;
+
+  await writeFile(join(distDir, 'index.d.ts'), content, 'utf-8');
+}
+
+/**
+ * Main build function
+ */
+async function build() {
+  console.log('Building @cloudsmith/rego-recipes...\n');
+
+  // Ensure dist directory exists
+  await mkdir(distDir, { recursive: true });
+
+  // Directories to scan for .rego files
+  const policyDirs = ['baseline', 'advanced', 'legacy'];
+
+  // Find all .rego files in each directory
+  /** @type {Record<string, Array<{absolutePath: string, relativePath: string, name: string}>>} */
+  const policiesByDir = {};
+  for (const dir of policyDirs) {
+    policiesByDir[dir] = await findRegoFiles(join(rootDir, dir), rootDir);
+  }
+
+  const allPolicies = Object.values(policiesByDir).flat();
+
+  console.log(`Found ${allPolicies.length} policy files:`);
+  for (const dir of policyDirs) {
+    console.log(`  - ${policiesByDir[dir].length} from ${dir}/`);
+  }
+  console.log('');
+
+  // Generate output files
+  console.log('Generating dist/index.js...');
+  await generateIndexJs(allPolicies, policiesByDir);
+
+  console.log('Generating dist/index.d.ts...');
+  await generateIndexDts(allPolicies, policiesByDir);
+
+  console.log('\n✓ Build complete!\n');
+
+  // List exported policy names
+  console.log('Exported policies:');
+  for (const policy of allPolicies) {
+    const identifier = toSafeIdentifier(policy.relativePath);
+    console.log(`  - ${identifier} (${policy.relativePath})`);
+  }
+}
+
+// Run build
+build().catch((error) => {
+  console.error('Build failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
This pull request introduces npm packaging support for the repository, enabling seamless integration with JavaScript/TypeScript applications. It adds a build system to auto-generate distributable modules, documentation for npm usage, and updates the repository metadata to reflect its new capabilities.

**NPM Packaging Enablement:**

* Added a `package.json` file to define the npm package, including entry points, exports, included files, build scripts, and metadata for publishing as `@cloudsmith/rego-recipes`.
* Introduced a build script (`scripts/build.js`) that scans all `.rego` policy files, extracts metadata, and generates both `dist/index.js` (JavaScript module) and `dist/index.d.ts` (TypeScript definitions) for consumption as an npm package.

**Documentation Updates:**

* Added a new `NPM.md` file with detailed installation instructions, usage examples, available exports, and TypeScript type definitions for consumers of the npm package.
* Updated the `README.md` to reference npm usage and the new documentation, making it clear how to consume the repository as an npm package.